### PR TITLE
fix and revamp existing code | wp 6.4.1 , wc 8.2.2

### DIFF
--- a/assets/js/upload-receipt-order.js
+++ b/assets/js/upload-receipt-order.js
@@ -27,7 +27,8 @@ jQuery(function ($) {
           var selection = image_frame.state().get('selection').first().toJSON()
           let url = new URL(selection.url)
           let path = url.pathname
-          $('.receipt_upload_path').val(path)
+
+          $('input[type=text]#receipt_upload_path').attr('value', path)
           $('#change_receipt_file').attr('src', selection.url)
           $('#receipt_upload_view_img').attr('src', selection.url)
         }

--- a/includes/class-duitnow-qr.php
+++ b/includes/class-duitnow-qr.php
@@ -7,7 +7,7 @@ if (!defined('ABSPATH')) {
 class DuitNow_QR_Payment_Gateway extends WC_Payment_Gateway
 {
     private $asset_url;
-
+    // this for woocomerce payment setting page
     /**
      * Constructor for the gateway.
      */
@@ -166,14 +166,45 @@ class DuitNow_QR_Payment_Gateway extends WC_Payment_Gateway
                     $relative_path = str_replace($upload_dir['basedir'], '', $file_path);
                     $image_url = $base_url . $relative_path;
                 ?>
+                    <style>
+                        .image-container {
+                            display: flex;
+                            justify-content: center;
+                            align-items: center;
+                            height: 300px;
+                            /* width: 200px; */
+                            /* Set a specific height for the container */
+                        }
 
-                    <div class=" text-center">
-                        <img src="<?= $this->asset_url . 'images/icon-duit-now.png' ?>" alt="DuitNow Icon" style="max-width: 80px;" />
-                        <div>
-                            <img src="<?= esc_url($image_url) ?>" alt="QR Code" style="max-width: 200px;" />
-                        </div>
+                        .image-container img {
+                            width: 70%;
+                            /* Adjust as needed */
+                            height: auto;
+                            max-height: 300px !important;
+                            /* Maintain aspect ratio */
+                        }
+
+                        .embed-container {
+                            position: relative;
+                            width: 100%;
+                            /* Set the width of the container */
+                            height: 0;
+                            padding-bottom: 56.25%;
+                            /* This creates a 16:9 aspect ratio (height/width) for the embed */
+                        }
+
+                        .embed-container embed {
+                            position: absolute;
+                            top: 0;
+                            left: 0;
+                            width: 100%;
+                            height: 100%;
+                            /* This ensures the embed takes the full size of its container */
+                        }
+                    </style>
+                    <div class="image-container">
+                        <img src="<?= esc_url($image_url) ?>" alt="QR Code" />
                     </div>
-
                 <?php } ?>
 
             </div>
@@ -187,7 +218,7 @@ class DuitNow_QR_Payment_Gateway extends WC_Payment_Gateway
                 <h5>Upload receipt to get email confirmation</h5>
                 <input type="hidden" name="receipt_upload" class="receipt_upload" />
                 <input type="file" class="receipt_upload_file" name="duitnow_qr_receipt_upload" id="duitnow_qr_receipt_upload" accept="image/*,.pdf" />
-                <embed src='#' class="receipt_preview" id="duitnow_qr_receipt_preview" width="400" height="400" style="display: none;">
+                <embed src='#' class="receipt_preview" id="duitnow_qr_receipt_preview" width="100%" height="400" style="display: none;">
             </div>
         </div>
 <?php

--- a/includes/partials/class-custom-payment-gateway-admin-column.php
+++ b/includes/partials/class-custom-payment-gateway-admin-column.php
@@ -7,8 +7,8 @@ class Custom_Payment_Gateway_Admin_Column
      */
     public function __construct()
     {
-        add_filter("manage_edit-shop_order_columns", array($this, "column_header"), 20);
-        add_action("manage_shop_order_posts_custom_column", array($this, "column_content"));
+        add_filter("manage_woocommerce_page_wc-orders_columns", [$this, "column_header"], 20);
+        add_action("manage_woocommerce_page_wc-orders_custom_column", [$this, "column_content"], 20, 2);
     }
 
     /**
@@ -33,16 +33,13 @@ class Custom_Payment_Gateway_Admin_Column
      *
      * @param string $column_name.
      */
-    public function column_content($column_name)
+    public function column_content($column_name, $post_data)
     {
-        global $post;
         if ('wcuploadrcp' !== $column_name) {
             return;
         }
-        $order_id = $post->ID;
-        $order = new WC_Order($post->ID);
-        $receipt_upload_path = get_post_meta($order_id, 'receipt_upload_path', true);
-
+        $order = new WC_Order($post_data->id);
+        $receipt_upload_path = get_post_meta($post_data->id, 'receipt_upload_path', true);
         $payment_method = $order->get_payment_method();
         $allowed_payment_methods = array('duitnow_qr_payment_gateway', 'bank_transfer_payment_gateway');
 

--- a/wc-malaysia-payment-gateway.php
+++ b/wc-malaysia-payment-gateway.php
@@ -27,6 +27,7 @@ function init_custom_payment_gateway()
         /**
          * This class is use to create metabox and show receipt in admin order page.
          */
+
         $metabox = new Custom_Payment_Gateway_MetaBox($asset_url);
 
         /**


### PR DESCRIPTION
- replace save_post to woocommerce_update_order
- remove shop_order post_type, replace with woocommerce_page_wc-orders
- fix add_meta_box not showing
- fix additional column at woocommerce orders page
- revamp qr placement , height & width at checkout page
- remove global $post , use default callback param

Tested on Wordpress version 6.4.1 , woocommerce 8.2.2, PHP 8.2